### PR TITLE
fix(typo): change asdf-ocaml to asdf-rust

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ install_rust() {
   local install_path=$3
 
   if [ "$install_type" != "version" ]; then
-    fail "asdf-ocaml supports release installs only"
+    fail "asdf-rust supports release installs only"
   fi
 
   local platform


### PR DESCRIPTION
Change little typo (asdf-ocaml to asdf-rust) inside `install` script. :bowing_man: 