### PR TITLE
Support ppc64le architecture

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -49,6 +49,7 @@ install_rust() {
     aarch64) architecture="aarch64" ;;
     xscale | armv6l | arm) architecture="arm" ;;
     armv7l | armv8l) architecture="armv7" ;;
+    ppc64le) architecture="powerpc64le" ;;
     *) fail "Unsupported architecture" ;;
   esac
 


### PR DESCRIPTION
## Context

Rust does offer [tier 2 support for ppc64le architecture](https://forge.rust-lang.org/release/platform-support.html) however this plugin does not offer an option for this platform.

## Changes

* Add a condition check for ppc64le

## How to reproduce the issue?

```
$ asdf version
v0.7.6-6207e42

$ lscpu
Architecture:                    ppc64le
Byte Order:                      Little Endian
CPU(s):                          32
On-line CPU(s) list:             0-31
Thread(s) per core:              4
Core(s) per socket:              8
Socket(s):                       1
NUMA node(s):                    1
Model:                           2.3 (pvr 004e 1203)
Model name:                      POWER9, altivec supported
Frequency boost:                 enabled
CPU max MHz:                     3800.0000
CPU min MHz:                     2154.0000
L1d cache:                       256 KiB
L1i cache:                       256 KiB
L2 cache:                        4 MiB
L3 cache:                        80 MiB
NUMA node0 CPU(s):               0-31
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Mitigation; RFI Flush, L1D private per thread
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Mitigation; RFI Flush, L1D private per thread
Vulnerability Spec store bypass: Mitigation; Kernel entry/exit barrier (eieio)
Vulnerability Spectre v1:        Mitigation; __user pointer sanitization, ori31 speculation barrier enabled
Vulnerability Spectre v2:        Mitigation; Software count cache flush (hardware accelerated), Software link stack flush
Vulnerability Tsx async abort:   Not affected

$ uname -a
Linux localhost.localdomain 5.4.12-200.fc31.ppc64le #1 SMP Tue Jan 14 19:52:00 UTC 2020 ppc64le ppc64le ppc64le GNU/Linux

$ asdf install rust 1.40.0
Fail: Unsupported architecture 😭
```

## Testing

I am able to install rust successfully with this patch on RaptorCS Blackbird with IBM POWER9 v2 8-core box:

```
$ asdf install rust 1.40.0
∗ Downloading...
∗ Installing...
install: creating uninstall script at /home/tle/.asdf/installs/rust/1.40.0/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'cargo'
install: installing component 'rls-preview'
install: installing component 'miri-preview'
install: installing component 'rustfmt-preview'
install: installing component 'llvm-tools-preview'
install: installing component 'rust-analysis-powerpc64le-unknown-linux-gnu'
install: installing component 'rust-std-powerpc64le-unknown-linux-gnu'
install: WARNING: failed to run ldconfig. this may happen when not installing as root. run with --verbose to see the error

    Rust is ready to roll.

The installation was successful!
```

## Consideration

It would be great if other platform than x86 could be tested in Github Actions.