### PR TITLE
feat: Add RUST_WITHOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ asdf plugin-add rust https://github.com/asdf-community/asdf-rust.git
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to
 install & manage versions.
 
+## Configuration
+
+By default, `asdf-rust` installs rust via [Standalone installers](https://forge.rust-lang.org/infra/other-installation-methods.html) with all included components.
+
+That include docs, which may easily use around ~50% of total installation. For this reason,  environment variable `RUST_WITHOUT` exists, which takes comma-separated list of components NOT to install:
+
+```sh
+RUST_WITHOUT=rust-docs,rust-other-component asdf install rust 1.51.0
+
+# Or in .profile
+export RUST_WITHOUT=rust-docs
+```
+
 ## License
 
 Licensed under the

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ install & manage versions.
 
 ## Configuration
 
-By default, `asdf-rust` installs rust via [Standalone installers](https://forge.rust-lang.org/infra/other-installation-methods.html) with all included components.
+By default, `asdf-rust` installs rust via
+[Standalone installers](https://forge.rust-lang.org/infra/other-installation-methods.html)
+with all included components.
 
-That include docs, which may easily use around ~50% of total installation. For this reason,  environment variable `RUST_WITHOUT` exists, which takes comma-separated list of components NOT to install:
+That include docs, which may easily use around ~50% of total installation. For
+this reason, environment variable `RUST_WITHOUT` exists, which takes
+comma-separated list of components NOT to install:
 
 ```sh
 RUST_WITHOUT=rust-docs,rust-other-component asdf install rust 1.51.0

--- a/bin/install
+++ b/bin/install
@@ -31,9 +31,9 @@ install_rust() {
     fail "asdf-rust supports release installs only"
   fi
 
-  local install_extra_flags=''
+  local install_without_opt=''
   if [ -n "${ASDF_RUST_IGNORE_COMPONENTS}" ]; then
-    install_extra_flags="--without=${ASDF_RUST_IGNORE_COMPONENTS} $install_extra_flags"
+    install_without_opt="--without=${ASDF_RUST_IGNORE_COMPONENTS}"
   fi
 
   local platform
@@ -72,7 +72,7 @@ install_rust() {
 
     echo "∗ Installing..."
     cd "$distination_path"
-    ./install.sh --prefix="$install_path" $install_extra_flags || fail "Could not install"
+    ./install.sh --prefix="$install_path" "$install_without_opt" || fail "Could not install"
 
     rm -rf "$tmp_download_dir"
 

--- a/bin/install
+++ b/bin/install
@@ -1,19 +1,4 @@
 #!/usr/bin/env bash
-#
-# Copyright 2019 asdf-rust authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 set -eo pipefail
 
@@ -31,9 +16,10 @@ install_rust() {
     fail "asdf-rust supports release installs only"
   fi
 
-  local install_without_opt=''
-  if [ -n "${ASDF_RUST_IGNORE_COMPONENTS}" ]; then
-    install_without_opt="--without=${ASDF_RUST_IGNORE_COMPONENTS}"
+  local configure_options="--prefix=$install_path"
+
+  if [ -n "${RUST_WITHOUT}" ]; then
+    configure_options+=" --without=${RUST_WITHOUT}"
   fi
 
   local platform
@@ -72,7 +58,7 @@ install_rust() {
 
     echo "∗ Installing..."
     cd "$distination_path"
-    ./install.sh --prefix="$install_path" "$install_without_opt" || fail "Could not install"
+    ./install.sh "$configure_options" || fail "Could not install"
 
     rm -rf "$tmp_download_dir"
 

--- a/bin/install
+++ b/bin/install
@@ -31,6 +31,11 @@ install_rust() {
     fail "asdf-rust supports release installs only"
   fi
 
+  local install_extra_flags=''
+  if [ -n "${ASDF_RUST_IGNORE_COMPONENTS}" ]; then
+    install_extra_flags="--without=${ASDF_RUST_IGNORE_COMPONENTS} $install_extra_flags"
+  fi
+
   local platform
 
   case "$OSTYPE" in
@@ -67,7 +72,7 @@ install_rust() {
 
     echo "∗ Installing..."
     cd "$distination_path"
-    ./install.sh --prefix="$install_path" || fail "Could not install"
+    ./install.sh --prefix="$install_path" $install_extra_flags || fail "Could not install"
 
     rm -rf "$tmp_download_dir"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,19 +1,4 @@
 #!/usr/bin/env bash
-#
-# Copyright 2019 asdf-rust authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 set -eo pipefail
 


### PR DESCRIPTION
## Description
Currently there's no way to skip installation of the docs (as well as
other components).
While helpful in general, on systems with a small amount of storage
(e.g. 128/256 GB) those megabytes can be a dealbreaker.
For the most recent stable version (1.51.0) it takes around __40%__ out
of
total space for the installation (__418/1145 MB__).

## Proposal
This PR introduces `ASDF_RUST_IGNORE_COMPONENTS` which is being passed
as
a value of option `--without` to the Rust `install` script. This option
takes comma-separated list of components to skip during installation
(e.g. `rust-docs,miri-preview` to skip installation of docs and MIRI
preview)

## Results
It greatly helps to save storage space.
As a side effect, it drastically decreases installation time: on my
machine, doc building takes a handful of time: __20/23 minutes__ of
installation (downloading + actual installation) was spent __building
docs__ I won't need.