### PR TITLE
feat: map arm64 to aarch64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,7 +37,7 @@ install_rust() {
   case "$(uname -m)" in
     x86_64 | x86-64 | x64 | amd64) architecture="x86_64" ;;
     i386 | i486 | i686 | i786 | x86) architecture="i686" ;;
-    aarch64) architecture="aarch64" ;;
+    aarch64 | arm64) architecture="aarch64" ;;
     xscale | armv6l | arm) architecture="arm" ;;
     armv7l | armv8l) architecture="armv7" ;;
     ppc64le) architecture="powerpc64le" ;;


### PR DESCRIPTION
arm64 and aarch64 refers to the same thing, so needs to map this as well. This will also allow macOS users using the M1 chip to install rust using this plugin.

Tested on Macbook Pro M1, everything works as expected.

![Captura de Tela 2021-04-16 às 20 02 47](https://user-images.githubusercontent.com/8826449/115091721-b8841100-9eee-11eb-87eb-6fdc4e6e85fd.png)
