### PR TITLE
Use statically linked musl version on Linux

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -26,7 +26,7 @@ install_rust() {
 
   case "$OSTYPE" in
     darwin*) platform="apple-darwin" ;;
-    linux*) platform="unknown-linux-gnu" ;;
+    linux*) platform="unknown-linux-musl" ;;
     openbsd*) platform="unknown-freebsd" ;;
     netbsd*) platform="unknown-netbsd" ;;
     *) fail "Unsupported platform" ;;


### PR DESCRIPTION
I run this plugin on a QNAP NAS which has an older GLIBC version (2.21). This means I'm stuck on Rust 1.58.1. Using the statically-linked musl version would allow Rust to run on systems that have older GLIBC versions.