### PR TITLE
Correct "plugin add" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 ## Installation
 
 ```bash
-asdf plugin-add rust https://github.com/asdf-community/asdf-rust.git
+asdf plugin add rust https://github.com/asdf-community/asdf-rust.git
 ```
 
 ## Usage
 
-Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to
-install & manage versions.
+Check the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on
+how to install & manage versions.
 
 ## Configuration
 
@@ -23,12 +23,12 @@ By default, `asdf-rust` installs rust via
 [Standalone installers](https://forge.rust-lang.org/infra/other-installation-methods.html)
 with all included components.
 
-That include docs, which may easily use around ~50% of total installation. For
-this reason, environment variable `RUST_WITHOUT` exists, which takes
+That includes the docs, which may easily be around ~50% of the total install size.
+For this reason there is a `RUST_WITHOUT` environment variable, which takes a
 comma-separated list of components NOT to install:
 
 ```sh
-RUST_WITHOUT=rust-docs,rust-other-component asdf install rust 1.51.0
+RUST_WITHOUT=rust-docs,rust-other-component asdf install rust 1.95.0
 
 # Or in .profile
 export RUST_WITHOUT=rust-docs


### PR DESCRIPTION
`plugin-add` is not a command on asdf 0.19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README installation command to use `asdf plugin add` (correct for asdf 0.19+). Also clarify `RUST_WITHOUT` docs and update the example to version `1.95.0`.

<sup>Written for commit 82e183f2445d274784a78dbe7bfc3be6936ce18e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

